### PR TITLE
Resource recollection on path change and smaller fixes

### DIFF
--- a/lib/gtfs/orm.rb
+++ b/lib/gtfs/orm.rb
@@ -15,7 +15,7 @@ module GTFS
     # CLASS METHODS
 
     def self.path=(path)
-      @path
+      @path = path
     end
 
     def self.path

--- a/lib/gtfs/orm/fare_attribute.rb
+++ b/lib/gtfs/orm/fare_attribute.rb
@@ -12,7 +12,7 @@ module GTFS
       attribute :price, Float
       attribute :currency_type, String
       attribute :payment_method, Integer
-      attribute :trqnsfers, Integer
+      attribute :transfers, Integer
       attribute :transfer_duration, Integer
 
       # INSTANCE METHODS

--- a/lib/gtfs/orm/resource.rb
+++ b/lib/gtfs/orm/resource.rb
@@ -59,12 +59,14 @@ module GTFS
       end
 
       def self.collection
-        unless @collection
+        # make sure we reload the data if the ORM.path changed
+        unless @collection && ORM.path == @last_path
           raise NonExistentResourceError unless File.exist?(file_path)
           @collection = []
           CSV.read(file_path, headers: true).map do |row|
             @collection << new( Hash[row.headers.zip(row.fields)] )
           end
+          @last_path = ORM.path.dup
         end
         @collection
       end

--- a/lib/gtfs/orm/stop_time.rb
+++ b/lib/gtfs/orm/stop_time.rb
@@ -9,8 +9,8 @@ module GTFS
       # ATTRIBUTES
 
       attribute :trip_id, String
-      attribute :arrival_time, Time
-      attribute :departure_time, Time
+      attribute :arrival_time, String
+      attribute :departure_time, String
       attribute :stop_id, String
       attribute :stop_sequence, Integer
       attribute :stop_headsign, String

--- a/lib/gtfs/orm/trip.rb
+++ b/lib/gtfs/orm/trip.rb
@@ -9,7 +9,7 @@ module GTFS
       # ATTRIBUTES
 
       attribute :route_id, String
-      attribute :service_id, Integer
+      attribute :service_id, String
       attribute :trip_id, String
       attribute :trip_headsign, String
       attribute :trip_short_name, String


### PR DESCRIPTION
Main objective of these changes was to:
1. fix typing and typos in some of the resources' attributes
2. Enable GTFS::ORM loaded class variable collection to reload on any change of the source path

The second point came up in a project where we needed to test several different gtfs source imports in a test suite - which failed due to GTFS::ORM::Resource not respecting the new source set by the path setter.
